### PR TITLE
Update Compatibility.lua

### DIFF
--- a/AI_VoiceOver/Compatibility.lua
+++ b/AI_VoiceOver/Compatibility.lua
@@ -76,8 +76,8 @@ function Utils:GetIDFromGUID(guid)
         return
     end
     local type = assert(self:GetGUIDType(guid), format([[Failed to determine the type of GUID "%s"]], guid))
-    assert(Enums.GUID:GetName(type), format([[Unknown GUID type %d]], type))
-    assert(Enums.GUID:CanHaveID(type), format([[GUID "%s" does not contain ID]], guid))
+    -- assert(Enums.GUID:GetName(type), format([[Unknown GUID type %d]], type))
+    -- assert(Enums.GUID:CanHaveID(type), format([[GUID "%s" does not contain ID]], guid))
     return tonumber(guid:sub(7, 7 + 6 - 1), 16)
 end
 


### PR DESCRIPTION
Commented ll. 79 & 80 because if you run the game with LUA errors enabled it turns annoying trying to open Dungeon Caches for example, since it's not a valid QuestID for the addon. I feel these should be commented and if someone is working on the addon they can simply remove those lines as comments